### PR TITLE
Add save and continue support to retro_wiki

### DIFF
--- a/extensions/retro_wiki/locales/app/cs-CZ.yml
+++ b/extensions/retro_wiki/locales/app/cs-CZ.yml
@@ -5,7 +5,7 @@ cs-CZ:
 
     # Missing
     # extensions/retro_wiki/lib/wiki_helper.rb
-    "Back in time": 
+    "Back in time":
 
     # extensions/retro_wiki/views/wiki/edit.html.erb
     # extensions/retro_wiki/views/wiki/rename.html.erb
@@ -21,7 +21,7 @@ cs-CZ:
 
     # Missing
     # extensions/retro_wiki/views/wiki/show.html.erb
-    "Created on %{date} by %{author}": 
+    "Created on %{date} by %{author}":
 
     # extensions/retro_wiki/ext_info.rb
     # extensions/retro_wiki/lib/wiki_helper.rb
@@ -34,29 +34,29 @@ cs-CZ:
     # Missing
     # extensions/retro_wiki/views/wiki_files/index.html.erb
     # extensions/retro_wiki/views/wiki_files/new.html.erb
-    File: 
+    File:
 
     # Missing
     # extensions/retro_wiki/lib/wiki_files_controller.rb
-    "File cannot be deleted.": 
+    "File cannot be deleted.":
 
     # Missing
     # extensions/retro_wiki/lib/wiki_files_controller.rb
-    "File was successfully added.": 
+    "File was successfully added.":
 
     # Missing
     # extensions/retro_wiki/lib/wiki_files_controller.rb
-    "File was successfully deleted.": 
+    "File was successfully deleted.":
 
     # Missing
     # extensions/retro_wiki/lib/wiki_helper.rb
     # extensions/retro_wiki/views/wiki/index.html.erb
     # extensions/retro_wiki/views/wiki_files/index.html.erb
-    Files: 
+    Files:
 
     # Missing
     # extensions/retro_wiki/lib/wiki_helper.rb
-    "Forward in time": 
+    "Forward in time":
 
     # extensions/retro_wiki/lib/wiki_helper.rb
     # extensions/retro_wiki/views/wiki/index.html.erb
@@ -71,21 +71,21 @@ cs-CZ:
 
     # Missing
     # extensions/retro_wiki/models/wiki_page.rb
-    "Nothing changed": 
+    "Nothing changed":
 
     # Missing
     # extensions/retro_wiki/lib/wiki_controller.rb
-    "Page was successfully created.": 
+    "Page was successfully created.":
 
     # Missing
     # extensions/retro_wiki/lib/wiki_controller.rb
-    "Page was successfully updated.": 
+    "Page was successfully updated.":
 
     # Missing
     # extensions/retro_wiki/lib/wiki_helper.rb
     # extensions/retro_wiki/views/wiki/index.html.erb
     # extensions/retro_wiki/views/wiki_files/index.html.erb
-    Pages: 
+    Pages:
 
     # extensions/retro_wiki/ext/markup_controller.rb
     References: Reference
@@ -94,59 +94,63 @@ cs-CZ:
     # extensions/retro_wiki/ext_info.rb
     # extensions/retro_wiki/lib/wiki_helper.rb
     # extensions/retro_wiki/views/wiki/rename.html.erb
-    Rename: 
+    Rename:
 
     # Missing
     # extensions/retro_wiki/lib/wiki_helper.rb
-    Rollback: 
+    Rollback:
 
     # extensions/retro_wiki/views/wiki/edit.html.erb
     Save: Uložit
 
+    # extensions/retro_wiki/views/wiki/edit.html.erb
+    # extensions/retro_wiki/lib/wiki_controller.rb
+    "Save and continue":
+
     # Missing
     # extensions/retro_wiki/lib/wiki_helper.rb
-    "Show current": 
+    "Show current":
 
     # extensions/retro_wiki/views/wiki_files/index.html.erb
     Size: Velikost
 
     # Missing
     # extensions/retro_wiki/views/wiki/index.html.erb
-    "Sort alphabetically": 
+    "Sort alphabetically":
 
     # Missing
     # extensions/retro_wiki/views/wiki/index.html.erb
-    "Sort by last update": 
+    "Sort by last update":
 
     # Missing
     # extensions/retro_wiki/views/wiki/edit.html.erb
     # extensions/retro_wiki/views/wiki/rename.html.erb
     # extensions/retro_wiki/views/wiki_files/new.html.erb
-    Title: 
+    Title:
 
     # Missing
     # extensions/retro_wiki/views/wiki_files/index.html.erb
-    Type: 
+    Type:
 
     # Missing
     # extensions/retro_wiki/lib/wiki_files_controller.rb
-    "Unable to download file": 
+    "Unable to download file":
 
     # extensions/retro_wiki/ext_info.rb
     Update: Upravit
 
     # Missing
     # extensions/retro_wiki/views/wiki/show.html.erb
-    "Updated on %{date} by %{author}": 
+    "Updated on %{date} by %{author}":
 
     # Missing
     # extensions/retro_wiki/views/wiki_files/index.html.erb
     # extensions/retro_wiki/views/wiki_files/new.html.erb
-    Upload: 
+    Upload:
 
     # Missing
     # extensions/retro_wiki/views/wiki/show.html.erb
-    Version: 
+    Version:
 
     # extensions/retro_wiki/ext_info.rb
     View: Zobrazit
@@ -158,25 +162,25 @@ cs-CZ:
     # extensions/retro_wiki/views/wiki/index.html.erb
     # extensions/retro_wiki/views/wiki_files/index.html.erb
     # extensions/retro_wiki/views/wiki_files/new.html.erb
-    Wiki: 
+    Wiki:
 
     # Missing
     # extensions/retro_wiki/ext_info.rb
-    "Wiki Files": 
+    "Wiki Files":
 
     # Missing
     # extensions/retro_wiki/ext_info.rb
-    "Wiki Pages": 
+    "Wiki Pages":
 
     # Missing
     # extensions/retro_wiki/models/wiki_page.rb
-    "Wiki for %{project}": 
+    "Wiki for %{project}":
 
     # Missing
     # extensions/retro_wiki/views/wiki/index.html.erb
-    updated: 
+    updated:
 
     # Missing
     # extensions/retro_wiki/lib/wiki_helper.rb
-    "%{count} more": 
+    "%{count} more":
 

--- a/extensions/retro_wiki/locales/app/de-DE.yml
+++ b/extensions/retro_wiki/locales/app/de-DE.yml
@@ -89,6 +89,10 @@ de-DE:
     # extensions/retro_wiki/views/wiki/edit.html.erb
     Save: Speichern
 
+    # extensions/retro_wiki/views/wiki/edit.html.erb
+    # extensions/retro_wiki/lib/wiki_controller.rb
+    "Save and continue":
+
     # extensions/retro_wiki/lib/wiki_helper.rb
     "Show current": "Aktuelle anzeigen"
 

--- a/extensions/retro_wiki/locales/app/en-GB.yml
+++ b/extensions/retro_wiki/locales/app/en-GB.yml
@@ -89,6 +89,10 @@ en-GB:
     # extensions/retro_wiki/views/wiki/edit.html.erb
     Save: Save
 
+    # extensions/retro_wiki/views/wiki/edit.html.erb
+    # extensions/retro_wiki/lib/wiki_controller.rb
+    "Save and continue": "Save and continue"
+
     # extensions/retro_wiki/lib/wiki_helper.rb
     "Show current": "Show current"
 

--- a/extensions/retro_wiki/locales/app/es-AR.yml
+++ b/extensions/retro_wiki/locales/app/es-AR.yml
@@ -5,7 +5,7 @@ es-AR:
 
     # Missing
     # extensions/retro_wiki/lib/wiki_helper.rb
-    "Back in time": 
+    "Back in time":
 
     # extensions/retro_wiki/views/wiki/edit.html.erb
     # extensions/retro_wiki/views/wiki/rename.html.erb
@@ -21,7 +21,7 @@ es-AR:
 
     # Missing
     # extensions/retro_wiki/views/wiki/show.html.erb
-    "Created on %{date} by %{author}": 
+    "Created on %{date} by %{author}":
 
     # extensions/retro_wiki/ext_info.rb
     # extensions/retro_wiki/lib/wiki_helper.rb
@@ -34,29 +34,29 @@ es-AR:
     # Missing
     # extensions/retro_wiki/views/wiki_files/index.html.erb
     # extensions/retro_wiki/views/wiki_files/new.html.erb
-    File: 
+    File:
 
     # Missing
     # extensions/retro_wiki/lib/wiki_files_controller.rb
-    "File cannot be deleted.": 
+    "File cannot be deleted.":
 
     # Missing
     # extensions/retro_wiki/lib/wiki_files_controller.rb
-    "File was successfully added.": 
+    "File was successfully added.":
 
     # Missing
     # extensions/retro_wiki/lib/wiki_files_controller.rb
-    "File was successfully deleted.": 
+    "File was successfully deleted.":
 
     # Missing
     # extensions/retro_wiki/lib/wiki_helper.rb
     # extensions/retro_wiki/views/wiki/index.html.erb
     # extensions/retro_wiki/views/wiki_files/index.html.erb
-    Files: 
+    Files:
 
     # Missing
     # extensions/retro_wiki/lib/wiki_helper.rb
-    "Forward in time": 
+    "Forward in time":
 
     # extensions/retro_wiki/lib/wiki_helper.rb
     # extensions/retro_wiki/views/wiki/index.html.erb
@@ -71,21 +71,21 @@ es-AR:
 
     # Missing
     # extensions/retro_wiki/models/wiki_page.rb
-    "Nothing changed": 
+    "Nothing changed":
 
     # Missing
     # extensions/retro_wiki/lib/wiki_controller.rb
-    "Page was successfully created.": 
+    "Page was successfully created.":
 
     # Missing
     # extensions/retro_wiki/lib/wiki_controller.rb
-    "Page was successfully updated.": 
+    "Page was successfully updated.":
 
     # Missing
     # extensions/retro_wiki/lib/wiki_helper.rb
     # extensions/retro_wiki/views/wiki/index.html.erb
     # extensions/retro_wiki/views/wiki_files/index.html.erb
-    Pages: 
+    Pages:
 
     # extensions/retro_wiki/ext/markup_controller.rb
     References: Referencias
@@ -94,59 +94,63 @@ es-AR:
     # extensions/retro_wiki/ext_info.rb
     # extensions/retro_wiki/lib/wiki_helper.rb
     # extensions/retro_wiki/views/wiki/rename.html.erb
-    Rename: 
+    Rename:
 
     # Missing
     # extensions/retro_wiki/lib/wiki_helper.rb
-    Rollback: 
+    Rollback:
 
     # extensions/retro_wiki/views/wiki/edit.html.erb
     Save: Guardar
 
+    # extensions/retro_wiki/views/wiki/edit.html.erb
+    # extensions/retro_wiki/lib/wiki_controller.rb
+    "Save and continue":
+
     # Missing
     # extensions/retro_wiki/lib/wiki_helper.rb
-    "Show current": 
+    "Show current":
 
     # extensions/retro_wiki/views/wiki_files/index.html.erb
     Size: Tamaño
 
     # Missing
     # extensions/retro_wiki/views/wiki/index.html.erb
-    "Sort alphabetically": 
+    "Sort alphabetically":
 
     # Missing
     # extensions/retro_wiki/views/wiki/index.html.erb
-    "Sort by last update": 
+    "Sort by last update":
 
     # Missing
     # extensions/retro_wiki/views/wiki/edit.html.erb
     # extensions/retro_wiki/views/wiki/rename.html.erb
     # extensions/retro_wiki/views/wiki_files/new.html.erb
-    Title: 
+    Title:
 
     # Missing
     # extensions/retro_wiki/views/wiki_files/index.html.erb
-    Type: 
+    Type:
 
     # Missing
     # extensions/retro_wiki/lib/wiki_files_controller.rb
-    "Unable to download file": 
+    "Unable to download file":
 
     # extensions/retro_wiki/ext_info.rb
     Update: Actualizar
 
     # Missing
     # extensions/retro_wiki/views/wiki/show.html.erb
-    "Updated on %{date} by %{author}": 
+    "Updated on %{date} by %{author}":
 
     # Missing
     # extensions/retro_wiki/views/wiki_files/index.html.erb
     # extensions/retro_wiki/views/wiki_files/new.html.erb
-    Upload: 
+    Upload:
 
     # Missing
     # extensions/retro_wiki/views/wiki/show.html.erb
-    Version: 
+    Version:
 
     # extensions/retro_wiki/ext_info.rb
     View: Ver
@@ -158,25 +162,25 @@ es-AR:
     # extensions/retro_wiki/views/wiki/index.html.erb
     # extensions/retro_wiki/views/wiki_files/index.html.erb
     # extensions/retro_wiki/views/wiki_files/new.html.erb
-    Wiki: 
+    Wiki:
 
     # Missing
     # extensions/retro_wiki/ext_info.rb
-    "Wiki Files": 
+    "Wiki Files":
 
     # Missing
     # extensions/retro_wiki/ext_info.rb
-    "Wiki Pages": 
+    "Wiki Pages":
 
     # Missing
     # extensions/retro_wiki/models/wiki_page.rb
-    "Wiki for %{project}": 
+    "Wiki for %{project}":
 
     # Missing
     # extensions/retro_wiki/views/wiki/index.html.erb
-    updated: 
+    updated:
 
     # Missing
     # extensions/retro_wiki/lib/wiki_helper.rb
-    "%{count} more": 
+    "%{count} more":
 

--- a/extensions/retro_wiki/locales/app/es-ES.yml
+++ b/extensions/retro_wiki/locales/app/es-ES.yml
@@ -5,7 +5,7 @@ es-ES:
 
     # Missing
     # extensions/retro_wiki/lib/wiki_helper.rb
-    "Back in time": 
+    "Back in time":
 
     # extensions/retro_wiki/views/wiki/edit.html.erb
     # extensions/retro_wiki/views/wiki/rename.html.erb
@@ -21,7 +21,7 @@ es-ES:
 
     # Missing
     # extensions/retro_wiki/views/wiki/show.html.erb
-    "Created on %{date} by %{author}": 
+    "Created on %{date} by %{author}":
 
     # extensions/retro_wiki/ext_info.rb
     # extensions/retro_wiki/lib/wiki_helper.rb
@@ -34,29 +34,29 @@ es-ES:
     # Missing
     # extensions/retro_wiki/views/wiki_files/index.html.erb
     # extensions/retro_wiki/views/wiki_files/new.html.erb
-    File: 
+    File:
 
     # Missing
     # extensions/retro_wiki/lib/wiki_files_controller.rb
-    "File cannot be deleted.": 
+    "File cannot be deleted.":
 
     # Missing
     # extensions/retro_wiki/lib/wiki_files_controller.rb
-    "File was successfully added.": 
+    "File was successfully added.":
 
     # Missing
     # extensions/retro_wiki/lib/wiki_files_controller.rb
-    "File was successfully deleted.": 
+    "File was successfully deleted.":
 
     # Missing
     # extensions/retro_wiki/lib/wiki_helper.rb
     # extensions/retro_wiki/views/wiki/index.html.erb
     # extensions/retro_wiki/views/wiki_files/index.html.erb
-    Files: 
+    Files:
 
     # Missing
     # extensions/retro_wiki/lib/wiki_helper.rb
-    "Forward in time": 
+    "Forward in time":
 
     # extensions/retro_wiki/lib/wiki_helper.rb
     # extensions/retro_wiki/views/wiki/index.html.erb
@@ -71,21 +71,21 @@ es-ES:
 
     # Missing
     # extensions/retro_wiki/models/wiki_page.rb
-    "Nothing changed": 
+    "Nothing changed":
 
     # Missing
     # extensions/retro_wiki/lib/wiki_controller.rb
-    "Page was successfully created.": 
+    "Page was successfully created.":
 
     # Missing
     # extensions/retro_wiki/lib/wiki_controller.rb
-    "Page was successfully updated.": 
+    "Page was successfully updated.":
 
     # Missing
     # extensions/retro_wiki/lib/wiki_helper.rb
     # extensions/retro_wiki/views/wiki/index.html.erb
     # extensions/retro_wiki/views/wiki_files/index.html.erb
-    Pages: 
+    Pages:
 
     # extensions/retro_wiki/ext/markup_controller.rb
     References: Referencias
@@ -94,59 +94,63 @@ es-ES:
     # extensions/retro_wiki/ext_info.rb
     # extensions/retro_wiki/lib/wiki_helper.rb
     # extensions/retro_wiki/views/wiki/rename.html.erb
-    Rename: 
+    Rename:
 
     # Missing
     # extensions/retro_wiki/lib/wiki_helper.rb
-    Rollback: 
+    Rollback:
 
     # extensions/retro_wiki/views/wiki/edit.html.erb
     Save: Guardar
 
+    # extensions/retro_wiki/views/wiki/edit.html.erb
+    # extensions/retro_wiki/lib/wiki_controller.rb
+    "Save and continue":
+
     # Missing
     # extensions/retro_wiki/lib/wiki_helper.rb
-    "Show current": 
+    "Show current":
 
     # extensions/retro_wiki/views/wiki_files/index.html.erb
     Size: Tamaño
 
     # Missing
     # extensions/retro_wiki/views/wiki/index.html.erb
-    "Sort alphabetically": 
+    "Sort alphabetically":
 
     # Missing
     # extensions/retro_wiki/views/wiki/index.html.erb
-    "Sort by last update": 
+    "Sort by last update":
 
     # Missing
     # extensions/retro_wiki/views/wiki/edit.html.erb
     # extensions/retro_wiki/views/wiki/rename.html.erb
     # extensions/retro_wiki/views/wiki_files/new.html.erb
-    Title: 
+    Title:
 
     # Missing
     # extensions/retro_wiki/views/wiki_files/index.html.erb
-    Type: 
+    Type:
 
     # Missing
     # extensions/retro_wiki/lib/wiki_files_controller.rb
-    "Unable to download file": 
+    "Unable to download file":
 
     # extensions/retro_wiki/ext_info.rb
     Update: Actualizar
 
     # Missing
     # extensions/retro_wiki/views/wiki/show.html.erb
-    "Updated on %{date} by %{author}": 
+    "Updated on %{date} by %{author}":
 
     # Missing
     # extensions/retro_wiki/views/wiki_files/index.html.erb
     # extensions/retro_wiki/views/wiki_files/new.html.erb
-    Upload: 
+    Upload:
 
     # Missing
     # extensions/retro_wiki/views/wiki/show.html.erb
-    Version: 
+    Version:
 
     # extensions/retro_wiki/ext_info.rb
     View: Ver
@@ -158,25 +162,25 @@ es-ES:
     # extensions/retro_wiki/views/wiki/index.html.erb
     # extensions/retro_wiki/views/wiki_files/index.html.erb
     # extensions/retro_wiki/views/wiki_files/new.html.erb
-    Wiki: 
+    Wiki:
 
     # Missing
     # extensions/retro_wiki/ext_info.rb
-    "Wiki Files": 
+    "Wiki Files":
 
     # Missing
     # extensions/retro_wiki/ext_info.rb
-    "Wiki Pages": 
+    "Wiki Pages":
 
     # Missing
     # extensions/retro_wiki/models/wiki_page.rb
-    "Wiki for %{project}": 
+    "Wiki for %{project}":
 
     # Missing
     # extensions/retro_wiki/views/wiki/index.html.erb
-    updated: 
+    updated:
 
     # Missing
     # extensions/retro_wiki/lib/wiki_helper.rb
-    "%{count} more": 
+    "%{count} more":
 

--- a/extensions/retro_wiki/locales/app/fr-FR.yml
+++ b/extensions/retro_wiki/locales/app/fr-FR.yml
@@ -89,6 +89,10 @@ fr-FR:
     # extensions/retro_wiki/views/wiki/edit.html.erb
     Save: Enregistrer
 
+    # extensions/retro_wiki/views/wiki/edit.html.erb
+    # extensions/retro_wiki/lib/wiki_controller.rb
+    "Save and continue":
+
     # extensions/retro_wiki/lib/wiki_helper.rb
     "Show current": "Afficher la version courante"
 

--- a/extensions/retro_wiki/locales/app/ja-JP.yml
+++ b/extensions/retro_wiki/locales/app/ja-JP.yml
@@ -92,6 +92,10 @@ ja-JP:
     # extensions/retro_wiki/views/wiki/edit.html.erb
     Save: 保存
 
+    # extensions/retro_wiki/views/wiki/edit.html.erb
+    # extensions/retro_wiki/lib/wiki_controller.rb
+    "Save and continue":
+
     # extensions/retro_wiki/lib/wiki_helper.rb
     "Show current": 最新版を表示
 

--- a/extensions/retro_wiki/locales/app/pt-BR.yml
+++ b/extensions/retro_wiki/locales/app/pt-BR.yml
@@ -92,6 +92,10 @@ pt-BR:
     # extensions/retro_wiki/views/wiki/edit.html.erb
     Save: Salvar
 
+    # extensions/retro_wiki/views/wiki/edit.html.erb
+    # extensions/retro_wiki/lib/wiki_controller.rb
+    "Save and continue":
+
     # extensions/retro_wiki/lib/wiki_helper.rb
     "Show current": "Exibir atual"
 
@@ -146,7 +150,7 @@ pt-BR:
     "Wiki Pages": "Páginas Wiki"
 
     # Unknown
-    "Wiki Pages for %{project}": 
+    "Wiki Pages for %{project}":
 
     # extensions/retro_wiki/models/wiki_page.rb
     "Wiki for %{project}": "Wiki para %{project}"

--- a/extensions/retro_wiki/locales/app/ru-RU.yml
+++ b/extensions/retro_wiki/locales/app/ru-RU.yml
@@ -20,7 +20,7 @@ ru-RU:
 
     # Missing
     # extensions/retro_wiki/views/wiki/show.html.erb
-    "Created on %{date} by %{author}": 
+    "Created on %{date} by %{author}":
 
     # extensions/retro_wiki/ext_info.rb
     # extensions/retro_wiki/lib/wiki_helper.rb
@@ -90,6 +90,10 @@ ru-RU:
     # extensions/retro_wiki/views/wiki/edit.html.erb
     Save: Сохранить
 
+    # extensions/retro_wiki/views/wiki/edit.html.erb
+    # extensions/retro_wiki/lib/wiki_controller.rb
+    "Save and continue":
+
     # extensions/retro_wiki/lib/wiki_helper.rb
     "Show current": "Актуальная версия"
 
@@ -144,7 +148,7 @@ ru-RU:
     "Wiki Pages": "Страницы Wiki"
 
     # Unknown
-    "Wiki Pages for %{project}": 
+    "Wiki Pages for %{project}":
 
     # extensions/retro_wiki/models/wiki_page.rb
     "Wiki for %{project}": "Wiki проекта %{project}"

--- a/extensions/retro_wiki/views/wiki/edit.html.erb
+++ b/extensions/retro_wiki/views/wiki/edit.html.erb
@@ -1,5 +1,5 @@
 <%= render :partial => 'header' %>
-    
+
 <div class="retro-wiki">
 
   <div class="page-title">
@@ -12,22 +12,23 @@
     <fieldset>
       <%= f.label_tag _('Title') + ':' %>
       <%=h @wiki_page.title %>
-    </fieldset>  
+    </fieldset>
 
     <fieldset>
       <%= f.label :author, _('Author') + ':' %>
       <%= f.text_field :author, :disabled => !User.current.public? %>
-    </fieldset>  
+    </fieldset>
 
     <fieldset>
       <%= f.label :content, _('Content') + ':' %>
       <%= markup_area :wiki_page, :content %>
-    </fieldset>  
-      
+    </fieldset>
+
     <fieldset>
-      <%= f.submit _('Save') %> | <%= link_to_function _('Cancel'), 'history.back()' %>
+      <%= f.submit _('Save') %> | <%= f.submit _('Save and continue') %> | <%= link_to_function _('Cancel'), 'history.back()' %>
     </fieldset>
 
   <% end -%>
 
 </div>
+


### PR DESCRIPTION
Hello,

I have added "save and continue" support to retro_wiki.
One commit contains the controller and view code, the other adds translation keys to all the translation files.

Regards,
Fredrik Wallgren
